### PR TITLE
Add routerbase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers) | MCP | Curated list of MCP servers and tool-use capabilities. | Awesome list, server links | Active | Medium |
 | [jaw9c/awesome-remote-mcp-servers](https://github.com/jaw9c/awesome-remote-mcp-servers) | MCP | Remote MCP server discovery. | Awesome list, remote services | Active | Medium |
 | [ai-boost/awesome-a2a](https://github.com/ai-boost/awesome-a2a) | A2A, MCP, Generic Agent | Agent2Agent tools, servers, clients, and integrations. | Awesome list, protocols, tooling | Active | Medium |
+| [zenlee123/routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) | Codex, Claude, Generic Agent | Use [routerbase](https://routerbase.com/) as an OpenAI-compatible gateway for model routing and media generation requests. | Agent skills, API workflow, examples | Active | Medium |
 
 ## Finance Skills
 

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -149,6 +149,7 @@ Aufnahmeleitlinie: 8-10 = empfohlen, 6-7 = akzeptabel mit Hinweisen, 4-5 = use w
 | [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers) | MCP | Kuratierte Liste von MCP servers und tool-use capabilities. | Awesome list, server links | Active | Medium |
 | [jaw9c/awesome-remote-mcp-servers](https://github.com/jaw9c/awesome-remote-mcp-servers) | MCP | Entdeckung von Remote MCP servers. | Awesome list, remote services | Active | Medium |
 | [ai-boost/awesome-a2a](https://github.com/ai-boost/awesome-a2a) | A2A, MCP, Generic Agent | Agent2Agent Tools, Servers, Clients und Integrationen. | Awesome list, protocols, tooling | Active | Medium |
+| [zenlee123/routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) | Codex, Claude, Generic Agent | Nutzt [routerbase](https://routerbase.com/) als OpenAI-kompatibles Gateway fuer Model Routing und Media Generation Requests. | Agent skills, API workflow, examples | Active | Medium |
 
 ## Finance Skills
 

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -149,6 +149,7 @@ Skills は掲載前にスコアリングします。Stars は弱いシグナル�
 | [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers) | MCP | MCP servers と tool-use capabilities の厳選リスト。 | Awesome list, server links | Active | Medium |
 | [jaw9c/awesome-remote-mcp-servers](https://github.com/jaw9c/awesome-remote-mcp-servers) | MCP | remote MCP server discovery。 | Awesome list, remote services | Active | Medium |
 | [ai-boost/awesome-a2a](https://github.com/ai-boost/awesome-a2a) | A2A, MCP, Generic Agent | Agent2Agent tools、servers、clients、integrations。 | Awesome list, protocols, tooling | Active | Medium |
+| [zenlee123/routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) | Codex, Claude, Generic Agent | [routerbase](https://routerbase.com/) を OpenAI 互換ゲートウェイとして使い、model routing と media generation requests を処理する。 | Agent skills, API workflow, examples | Active | Medium |
 
 ## Finance Skills
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -149,6 +149,7 @@ Guia de inclusão: 8-10 = recomendado, 6-7 = aceitável com ressalvas, 4-5 = use
 | [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers) | MCP | Lista curada de MCP servers e capacidades de tool-use. | Awesome list, server links | Active | Medium |
 | [jaw9c/awesome-remote-mcp-servers](https://github.com/jaw9c/awesome-remote-mcp-servers) | MCP | Descoberta de MCP servers remotos. | Awesome list, remote services | Active | Medium |
 | [ai-boost/awesome-a2a](https://github.com/ai-boost/awesome-a2a) | A2A, MCP, Generic Agent | Ferramentas, servers, clients e integrações Agent2Agent. | Awesome list, protocols, tooling | Active | Medium |
+| [zenlee123/routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) | Codex, Claude, Generic Agent | Usa [routerbase](https://routerbase.com/) como gateway compatível com OpenAI para roteamento de modelos e pedidos de geração de mídia. | Agent skills, API workflow, examples | Active | Medium |
 
 ## Finance Skills
 

--- a/i18n/README.ru.md
+++ b/i18n/README.ru.md
@@ -149,6 +149,7 @@ Skills оцениваются перед включением. Stars — тол�
 | [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers) | MCP | Curated list MCP servers и tool-use capabilities. | Awesome list, server links | Active | Medium |
 | [jaw9c/awesome-remote-mcp-servers](https://github.com/jaw9c/awesome-remote-mcp-servers) | MCP | Обнаружение remote MCP servers. | Awesome list, remote services | Active | Medium |
 | [ai-boost/awesome-a2a](https://github.com/ai-boost/awesome-a2a) | A2A, MCP, Generic Agent | Agent2Agent tools, servers, clients и integrations. | Awesome list, protocols, tooling | Active | Medium |
+| [zenlee123/routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) | Codex, Claude, Generic Agent | Использует [routerbase](https://routerbase.com/) как OpenAI-compatible gateway для model routing и media generation requests. | Agent skills, API workflow, examples | Active | Medium |
 
 ## Finance Skills
 

--- a/i18n/README.zh-CN.md
+++ b/i18n/README.zh-CN.md
@@ -149,6 +149,7 @@ Skill 收录前需要评分。Star 只是弱信号；小众 skill 如果能解�
 | [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers) | MCP | MCP server 和 tool-use 能力精选列表。 | Awesome list, server links | Active | Medium |
 | [jaw9c/awesome-remote-mcp-servers](https://github.com/jaw9c/awesome-remote-mcp-servers) | MCP | 远程 MCP server 发现。 | Awesome list, remote services | Active | Medium |
 | [ai-boost/awesome-a2a](https://github.com/ai-boost/awesome-a2a) | A2A, MCP, Generic Agent | Agent2Agent 工具、server、client 和集成。 | Awesome list, protocols, tooling | Active | Medium |
+| [zenlee123/routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) | Codex, Claude, Generic Agent | 通过 [routerbase](https://routerbase.com/) 作为 OpenAI 兼容网关来处理模型路由和媒体生成请求。 | Agent skills, API workflow, examples | Active | Medium |
 
 ## Finance Skills
 


### PR DESCRIPTION
## Summary
- Add zenlee123/routerbase-agent-skills to the MCP and Tool Integration section.
- Keep the English and localized README tables aligned.

## Why
routerbase-agent-skills provides reusable Agent Skills for using routerbase as an OpenAI-compatible gateway for model routing, API integration, and media generation workflows.

## Validation
- Confirmed each README variant contains one routerbase anchor link to https://routerbase.com/.
- Confirmed each README table has the same number of listed entries.
