### PR TITLE
Add sergebulaev/instagram-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 |---|---|---|---|---|---|
 | [enescingoz/awesome-n8n-templates](https://github.com/enescingoz/awesome-n8n-templates) | n8n, Generic Agent | Large workflow template collection for AI agents and business automation. | Workflow templates, integrations | Active | Medium |
 | [lucaswalter/n8n-ai-automations](https://github.com/lucaswalter/n8n-ai-automations) | n8n | AI automations and agent workflows for business tools. | n8n workflows, examples | Active | Medium |
+| [sergebulaev/instagram-skills](https://github.com/sergebulaev/instagram-skills) | Claude Code, Codex, Generic Agent | Instagram content workflows for captions, carousels, hashtag strategy, hook extraction, humanizing AI drafts, and weekly planning. | Skills, references, scripts, workflows | Active | Medium |
 
 ## Personal Productivity
 


### PR DESCRIPTION
Adds sergebulaev/instagram-skills to Business Workflows.

Six MIT-licensed skills for Instagram content work in Claude Code, Codex, and other SKILL.md-compatible agents: caption writer, carousel planner, hashtag strategist, hook extractor, content planner, and a humanizer that scrubs AI tells with a pre-publish audit step. Each skill ships as a SKILL.md package with shared references, a Python lib, and scripts; publishing is opt-in and behind explicit confirmation.

Self-scored against the rubric:

- Task clarity: 2 (each skill states use case, inputs, outputs, and target user)
- Reusable structure: 2 (skill files, shared references, lib, scripts, plugin manifests)
- Platform and tool fit: 2 (Claude Code plugin, Codex plugin, generic SKILL.md)
- Validation and examples: 1 (sample usage and audit checklists; no CI evals yet)
- Maintenance and safety: 2 (MIT, active commits, .env.example, confirmation before any publish)

Total: 9.

PR checklist:

- [x] Link points to the canonical repository.
- [x] The project is not just a prompt dump.
- [x] Evaluation score is at least 6, or the PR explains why a lower-scoring skill is still worth tracking.
- [x] Platform, use case, includes, status, and risk are filled.
- [x] Safety caveats are included for sensitive workflows.
- [x] Link check passes.
