### PR TITLE
Add UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 |---|---|---|---|---|---|
 | [LingyiChen-AI/comfyui-workflow-skill](https://github.com/LingyiChen-AI/comfyui-workflow-skill) | Claude Code, Cursor, Generic Agent | Generate ComfyUI workflow JSON from natural language. | Templates, node definitions, model workflows | Active | Medium |
 | [SlavaSexton/ComfyUI-Agent-Kit](https://github.com/SlavaSexton/ComfyUI-Agent-Kit) | Claude Code, Codex, Gemini CLI | Drive local ComfyUI end to end from an agent. | Skill, prompt recipes, templates, automation | Active | Medium |
-| [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze) | Codex, Claude Code, Cursor, Copilot, MCP | Ground UI work in 800,000+ real screen references at [uizze.com](https://uizze.com), write a design contract, and reject generic output at a finish gate. | Skill, workflow, examples, MCP option | Active | Medium |
+| [UIZZE anti-ui-slop](https://github.com/uizze/uizze) | Codex, Claude Code, Cursor, Copilot, MCP | Ground UI work in 800,000+ real screen references at [uizze.com](https://uizze.com), write a design contract, and reject generic output at a finish gate. | Skill, workflow, examples, MCP option | Active | Medium |
 
 ## Browser and Web
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 |---|---|---|---|---|---|
 | [LingyiChen-AI/comfyui-workflow-skill](https://github.com/LingyiChen-AI/comfyui-workflow-skill) | Claude Code, Cursor, Generic Agent | Generate ComfyUI workflow JSON from natural language. | Templates, node definitions, model workflows | Active | Medium |
 | [SlavaSexton/ComfyUI-Agent-Kit](https://github.com/SlavaSexton/ComfyUI-Agent-Kit) | Claude Code, Codex, Gemini CLI | Drive local ComfyUI end to end from an agent. | Skill, prompt recipes, templates, automation | Active | Medium |
+| [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze) | Codex, Claude Code, Cursor, Copilot, MCP | Ground UI work in 800,000+ real screen references at [uizze.com](https://uizze.com), write a design contract, and reject generic output at a finish gate. | Skill, workflow, examples, MCP option | Active | Medium |
 
 ## Browser and Web
 


### PR DESCRIPTION
## Summary\n\nAdds UIZZE anti-ui-slop to **Design and Frontend**. The entry points to the canonical MIT-licensed skill repository and includes one direct uizze.com link with no tracking parameters or pricing.\n\nThe free skill gives Codex, Claude Code, Cursor, and Copilot a repeatable workflow: inspect the product, ground design decisions in the public 800,000+ screen catalogue, write a design contract, then reject generic UI at a finish gate. The optional MCP automates the same workflow.\n\n**Disclosure:** I maintain UIZZE.\n\n## Validation\n\n- Confirmed no duplicate UIZZE entry before submission.\n- Ran git diff --check on README.md.\n- Verified the new row preserves the repository table contract.\n- Confirmed https://uizze.com and https://github.com/uizze/uizze return HTTP 200.