### PR TITLE
Add plasma-ai/wiki to Personal Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [Daaaaave/agentic-workspace-core](https://github.com/Daaaaave/agentic-workspace-core) | Claude Code, Codex | Repository-native memory, skills, and knowledge workflows. | Memory, AGENTS.md, skills, llms.txt | Active | Medium |
 | [WoJiSama/skill-based-architecture](https://github.com/WoJiSama/skill-based-architecture) | Cursor, Claude Code, Codex, Gemini | Meta-skill that distills repo knowledge into reusable skills. | Meta-skill, project skill generation | Active | Medium |
 | [mksglu/context-mode](https://github.com/mksglu/context-mode) | Claude Code, Codex, Cursor, MCP | Optimize agent context windows with tool-output sandboxing, session memory, MCP, and hooks. | MCP server, hooks, skills, memory, plugins | Active | Medium |
+| [plasma-ai/wiki](https://github.com/plasma-ai/wiki) | Claude Code, Codex, CLI | Build, index, search, and maintain structured Markdown knowledge bases. | Skill, CLI, validation, Obsidian integration | Active | Medium |
 
 ## Use With Care
 


### PR DESCRIPTION
## Summary

Add [plasma-ai/wiki](https://github.com/plasma-ai/wiki) to **Personal Productivity**.

The project provides a reusable Agent Skill and CLI for creating, indexing, searching, reading, updating, and linting structured Markdown knowledge bases. It documents installation, inputs and outputs, validation, examples, and a trust boundary for hook installation.

Evaluation score: 10/10

- Task clarity: 2/2
- Reusable structure: 2/2
- Platform and tool fit: 2/2
- Validation and examples: 2/2
- Maintenance and safety: 2/2

## Checklist

- [x] Link points to the canonical repository.
- [x] The project is not just a prompt dump.
- [x] Evaluation score is at least 6.
- [x] Platform, use case, includes, status, and risk are filled.
- [x] Safety caveats are documented for file modifications and hook installation.
- [x] Link check completed.

Disclosure: I'm affiliated with the project.