### PR TITLE
Add OrkasVideoStudio agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [LingyiChen-AI/comfyui-workflow-skill](https://github.com/LingyiChen-AI/comfyui-workflow-skill) | Claude Code, Cursor, Generic Agent | Generate ComfyUI workflow JSON from natural language. | Templates, node definitions, model workflows | Active | Medium |
 | [SlavaSexton/ComfyUI-Agent-Kit](https://github.com/SlavaSexton/ComfyUI-Agent-Kit) | Claude Code, Codex, Gemini CLI | Drive local ComfyUI end to end from an agent. | Skill, prompt recipes, templates, automation | Active | Medium |
 | [calesthio/OpenMontage](https://github.com/calesthio/OpenMontage) | Claude Code, Codex, Cursor, Copilot, Windsurf | End-to-end agentic video production from research and scripting through asset generation, editing, localization, rendering, and post-render QA. | 12 pipelines, 100+ tools, 700+ skills, schemas, Remotion, FFmpeg, tests | Active | High |
+| [Orkas-AI/Orkas-VideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) | Claude Code, Codex, Cursor, Generic Agent, MCP | Compose, edit, generate, transcribe, and assemble videos from editable timelines. | 14 skills, CLI, MCP server, `plan.json` schema, delivery guard, tests | Active | High |
 
 ## Browser and Web
 


### PR DESCRIPTION
Adds OrkasVideoStudio to Design and Frontend as an agentic video-production skill set.

## Evaluation score: 9/10

- Task clarity: 2/2 — inputs, editable `plan.json` output, and compose/edit/generate/auto routes are documented.
- Reusable structure: 2/2 — 14 `SKILL.md` files plus schemas, staged workflows, CLI, and MCP server.
- Platform and tool fit: 2/2 — supports Codex, Claude Code, generic shell-capable agents, and MCP clients.
- Validation and examples: 2/2 — tests, delivery guard, source-install steps, examples, and deterministic verification commands.
- Maintenance and safety: 1/2 — active and MIT-licensed with BYO-provider-key guidance, but it changes local files and runs media tooling.

## Risk: High

The entry explicitly uses High because video workflows can modify files, execute local tools, and call provider APIs. The core compose/edit/transcribe path is zero-key; generation is opt-in and uses the user's own provider keys.

Validation: canonical repository link returned HTTP 200 and `git diff --check` passes.