### PR TITLE
Add tidy-my-stars skill bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [Daaaaave/agentic-workspace-core](https://github.com/Daaaaave/agentic-workspace-core) | Claude Code, Codex | Repository-native memory, skills, and knowledge workflows. | Memory, AGENTS.md, skills, llms.txt | Active | Medium |
 | [WoJiSama/skill-based-architecture](https://github.com/WoJiSama/skill-based-architecture) | Cursor, Claude Code, Codex, Gemini | Meta-skill that distills repo knowledge into reusable skills. | Meta-skill, project skill generation | Active | Medium |
 | [mksglu/context-mode](https://github.com/mksglu/context-mode) | Claude Code, Codex, Cursor, MCP | Optimize agent context windows with tool-output sandboxing, session memory, MCP, and hooks. | MCP server, hooks, skills, memory, plugins | Active | Medium |
+| [z116123123x/tidy-my-stars](https://github.com/z116123123x/tidy-my-stars) | Generic Agent | Run two portable skills as one flow to organize GitHub Stars into overlapping Lists and generate a searchable review report. | Skills, workflow, scripts, references, report, examples | Active | High |
 
 ## Use With Care
 


### PR DESCRIPTION
## Summary

- Adds the canonical `z116123123x/tidy-my-stars` repository to Personal Productivity.
- Describes the repository as two portable Agent Skills that work as one flow: overlapping GitHub Lists plus a searchable review report.
- Marks risk as High because an explicitly authorized apply performs a delete-first full Lists rebuild. The default plan is read-only, the workflow never unstars repositories, and the project documents exact-diff authorization, recovery, verification, and private-report handling.

## Evaluation

**10/10**

- Task clarity: 2/2 — clear GitHub Stars organization and review workflow with defined inputs and outputs.
- Reusable structure: 2/2 — two bundled skills, workflows, scripts, references, schemas, and a complete report system.
- Platform and tool fit: 2/2 — portable Agent Skills with explicit GitHub, network, filesystem, Node.js, npm, and browser requirements; no AI provider or model is pinned.
- Validation and examples: 2/2 — CI, schema validation, deterministic tests, React tests/build checks, and a synthetic report preview.
- Maintenance and safety: 2/2 — active project, Apache-2.0 license, explicit write authorization, pre-write recovery journal, post-write verification, no automatic unstar, and privacy guidance.

## Checklist

- [x] Link points to the canonical repository.
- [x] The project is not just a prompt dump.
- [x] Evaluation score is at least 6.
- [x] Platform, use case, includes, status, and risk are filled.
- [x] Safety caveats are included for the account-writing workflow.
- [x] The canonical repository link resolves.
