### PR TITLE
Add Lians memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 |---|---|---|---|---|---|
 | [Benkapner/claude-code-basecamp](https://github.com/Benkapner/claude-code-basecamp) | Claude Code | Workspace setup with skills, commands, and hooks. | Skills, commands, hooks | Active | Medium |
 | [Daaaaave/agentic-workspace-core](https://github.com/Daaaaave/agentic-workspace-core) | Claude Code, Codex | Repository-native memory, skills, and knowledge workflows. | Memory, AGENTS.md, skills, llms.txt | Active | Medium |
+| [Lians Memory](https://github.com/Lians-ai/Lians) | Codex, Claude Code, MCP, Generic Agent | Give agents durable local memory, point-in-time recall, and an explicitly confirmed deletion path. | Skill, MCP server, CLI, tests | Active | Medium |
 | [WoJiSama/skill-based-architecture](https://github.com/WoJiSama/skill-based-architecture) | Cursor, Claude Code, Codex, Gemini | Meta-skill that distills repo knowledge into reusable skills. | Meta-skill, project skill generation | Active | Medium |
 | [mksglu/context-mode](https://github.com/mksglu/context-mode) | Claude Code, Codex, Cursor, MCP | Optimize agent context windows with tool-output sandboxing, session memory, MCP, and hooks. | MCP server, hooks, skills, memory, plugins | Active | Medium |
 


### PR DESCRIPTION
## Summary

Add Lians Memory to Personal Productivity as a reusable memory skill for Codex, Claude Code, and MCP-compatible agents.

## Evaluation score: 10/10

| Area | Score | Evidence |
|---|---:|---|
| Task clarity | 2 | The skill covers explicit durable storage, bounded recall, point-in-time queries, and confirmed forgetting. |
| Reusable structure | 2 | The repository includes SKILL.md packages, MCP configuration, commands, examples, and client integrations. |
| Platform and tool fit | 2 | It supports Codex, Claude Code, and generic MCP clients through the same local server. |
| Validation and examples | 2 | The repository includes automated tests, a copy-paste llms-install.md, and direct verification steps. |
| Maintenance and safety | 2 | v0.5.0 is current, the project is Apache-2.0, local mode needs no API key, and irreversible deletion requires fresh explicit confirmation. |

## Verification

- Canonical repository: https://github.com/Lians-ai/Lians
- Release: https://github.com/Lians-ai/Lians/releases/tag/v0.5.0
- `git diff --check` passes.

## Disclosure

I maintain Lians. Codex assisted with this factual one-row submission and rubric review, and I verified the claims and diff before publishing it.