### PR TITLE
Add Orkas VideoStudio agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [LingyiChen-AI/comfyui-workflow-skill](https://github.com/LingyiChen-AI/comfyui-workflow-skill) | Claude Code, Cursor, Generic Agent | Generate ComfyUI workflow JSON from natural language. | Templates, node definitions, model workflows | Active | Medium |
 | [SlavaSexton/ComfyUI-Agent-Kit](https://github.com/SlavaSexton/ComfyUI-Agent-Kit) | Claude Code, Codex, Gemini CLI | Drive local ComfyUI end to end from an agent. | Skill, prompt recipes, templates, automation | Active | Medium |
 | [calesthio/OpenMontage](https://github.com/calesthio/OpenMontage) | Claude Code, Codex, Cursor, Copilot, Windsurf | End-to-end agentic video production from research and scripting through asset generation, editing, localization, rendering, and post-render QA. | 12 pipelines, 100+ tools, 700+ skills, schemas, Remotion, FFmpeg, tests | Active | High |
+| [Orkas-AI/Orkas-VideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) | Claude Code, Codex, MCP | Plan and render agent-driven videos from editable timelines. | 14 skills, CLI, MCP server, timeline schema, renderer | Active | Medium |
 
 ## Browser and Web
 


### PR DESCRIPTION
## Summary

Adds Orkas VideoStudio to Design and Frontend as a cross-agent video-production skill collection with CLI and MCP surfaces.

## Evaluation

- Score: 9/10 — clear task, reusable skills and schemas, cross-agent support, examples and checks, active MIT repository
- Status: Active
- Risk: Medium — writes project files and can call optional provider APIs

## Validation

- Canonical repository and no duplicate entry verified
- Table schema and `git diff --check` verified