### PR TITLE
Add LWC project memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 |---|---|---|---|---|---|
 | [Benkapner/claude-code-basecamp](https://github.com/Benkapner/claude-code-basecamp) | Claude Code | Workspace setup with skills, commands, and hooks. | Skills, commands, hooks | Active | Medium |
 | [Daaaaave/agentic-workspace-core](https://github.com/Daaaaave/agentic-workspace-core) | Claude Code, Codex | Repository-native memory, skills, and knowledge workflows. | Memory, AGENTS.md, skills, llms.txt | Active | Medium |
+| [JanYork/llm-wiki-cli](https://github.com/JanYork/llm-wiki-cli) | Codex, Claude Code, Cursor, OpenCode, Gemini CLI, MCP | Persistent source-grounded project memory with bounded recall, citations, atomic changesets, and optional document and code graphs. | Skill, CLI, MCP server, memory, graphs | Active | Medium |
 | [WoJiSama/skill-based-architecture](https://github.com/WoJiSama/skill-based-architecture) | Cursor, Claude Code, Codex, Gemini | Meta-skill that distills repo knowledge into reusable skills. | Meta-skill, project skill generation | Active | Medium |
 | [mksglu/context-mode](https://github.com/mksglu/context-mode) | Claude Code, Codex, Cursor, MCP | Optimize agent context windows with tool-output sandboxing, session memory, MCP, and hooks. | MCP server, hooks, skills, memory, plugins | Active | Medium |
 


### PR DESCRIPTION
## Summary

Adds LWC to Personal Productivity as a reusable project-memory Skill and CLI for Codex, Claude Code, Cursor, OpenCode, Gemini CLI, and MCP-compatible agents.

## Evaluation score: 10/10

| Area | Score | Evidence |
|---|---:|---|
| Task clarity | 2 | Provides persistent project memory, bounded recall, source ingestion, citations, and verified writeback. |
| Reusable structure | 2 | Includes an installable SKILL.md package, CLI, references, MCP server, and optional graph workflows. |
| Platform and tool fit | 2 | Supports Codex, Claude Code, Cursor, OpenCode, Gemini CLI, Kiro, Hermes, Antigravity, pi, and MCP clients. |
| Validation and examples | 2 | The repository includes automated tests, documented lifecycle checks, installation commands, and verification workflows. |
| Maintenance and safety | 2 | Actively maintained, Apache-2.0 licensed, read-only MCP exploration, bounded retrieval, and atomic changesets. |

## Verification

- Canonical repository: https://github.com/JanYork/llm-wiki-cli
- Direct Skill: https://github.com/JanYork/llm-wiki-cli/tree/main/skills/using-lwc
- `git diff --check` passes.

## Disclosure

This is a self-nomination; I maintain LWC. Codex assisted with the factual one-row submission and rubric review, and I verified the claims and diff before publishing it.
