### PR TITLE
Add SandBase Skills registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills) | Generic Agent, Claude, Codex | Official Vercel collection of agent skills. | Skills, examples, workflows | Active | Medium |
 | [farion1231/cc-switch](https://github.com/farion1231/cc-switch) | Claude Code, Codex, OpenCode, Gemini CLI | Desktop skills and provider manager for multiple coding agents. | Desktop app, skills management, provider switching | Active | Medium |
 | [microsoft/SkillOpt](https://github.com/microsoft/SkillOpt) | Codex, Claude Code, Copilot, Cursor, Devin | Train, evaluate, and continuously improve reusable agent skills with trajectory-driven edits and held-out validation gates. | Skill optimizer, evals, benchmarks, plugins, WebUI | Active | High |
+| [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) | Claude Code, Codex, Cursor, Gemini CLI | 88 installable skills for research, social intelligence, marketing, and business workflows. | Skills, references, installer, tests | Active | Medium |
 
 ## Coding
 


### PR DESCRIPTION
## Summary

Add `sandbaseai/sandbase-skills` to the Core Skill Registries table.

It contains 88 installable Agent Skills for research, social intelligence, marketing, and business workflows. The repository includes reference files, installer support, inventory tests, an Apache-2.0 license, and documented compatibility with Claude Code, Codex, Cursor, and Gemini CLI.

## Evaluation

- task clarity: clear workflows and expected outputs
- reusable structure: 88 `SKILL.md` packages with references
- platform fit: four documented agent clients
- validation: automated inventory and package tests
- maintenance and safety: active releases, license, and API-key guidance

Risk is marked Medium because the skills call external APIs.

## Checks

- follows the required table format
- canonical repository URL returns HTTP 200
- no existing SandBase entry is present