### PR TITLE
Add agent-qa to Browser and Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) | MCP | Browser automation through Playwright MCP. | MCP server, browser tools | Active | Medium |
 | [executeautomation/mcp-playwright](https://github.com/executeautomation/mcp-playwright) | MCP, Claude, Cursor | Browser and API automation through Playwright. | MCP server, Playwright workflows | Active | Medium |
 | [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) | MCP | Let agents control cloud browsers with Browserbase and Stagehand. | MCP server, browser control | Active | Medium |
+| [vostride/agent-qa](https://github.com/vostride/agent-qa) | Claude Code, Codex, MCP | Author, run, triage, and debug natural-language web and mobile tests. | Three skills, CLI, MCP, memory, artifacts | Active | High |
 | [soxoj/awesome-osint-mcp-servers](https://github.com/soxoj/awesome-osint-mcp-servers) | MCP | OSINT tool discovery for research agents. | Curated MCP server list | Active | High |
 
 ## Security Skills


### PR DESCRIPTION
## Summary

Adds agent-qa to **Browser and Web**. Its repository includes three reusable skills for authoring tests, triaging run results, and debugging/fixing failures, alongside its CLI and MCP server.

## Evaluation

Score: **9/10**

- Task clarity: 2/2
- Reusable structure: 2/2
- Platform and tool fit: 2/2
- Validation and examples: 2/2
- Maintenance and safety: 1/2

The row is marked **High** risk because browser and mobile test scenarios can change application state or touch authenticated environments. Runs should use dedicated test environments and reviewers should inspect scenarios and hooks before execution.

## Validation

- `node skills/scripts/validate-skills.mjs` passes in the source repository.
- The canonical repository and documentation URLs return HTTP 200.
- The project is active and was not already listed or proposed.
- Table structure and `git diff --check` pass.

Project disclosure: this submission is for agent-qa itself.
