### PR TITLE
Add golang-curated-agent-skills (Go) to Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [obra/superpowers](https://github.com/obra/superpowers) | Claude Code, Codex, Cursor, Copilot | Agentic software development methodology packaged as composable skills. | Skills framework, plugins, hooks, tests | Active | Medium |
 | [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) | Claude Code, Codex, Cursor, Gemini CLI | Turn codebases, schemas, docs, and media into a queryable knowledge graph for coding agents. | Knowledge graph, CLI, skills, tests | Active | Medium |
 | [affaan-m/ECC](https://github.com/affaan-m/ECC) | Claude Code, Codex, Cursor, OpenCode | Harness optimization system with skills, memory, security, and research discipline. | Skills, memory, security workflows, MCP | Active | Medium |
+| [matdev83/golang-curated-agent-skills](https://github.com/matdev83/golang-curated-agent-skills) | Claude Code, Codex, Cursor, OpenCode | Portable Go workflows for concurrency, context, testing, benchmarks, and idiomatic style. | 44 SKILL.md skills, references, examples | Active | Medium |
 
 ## Data Analysis
 


### PR DESCRIPTION
Adds [matdev83/golang-curated-agent-skills](https://github.com/matdev83/golang-curated-agent-skills) to the **Coding** table.

**Checking against CONTRIBUTING.md table format** (Skill | Platform | Use case | Includes | Status | Risk):
- [x] Valid GitHub repo link
- [x] Platforms listed (Claude Code, Codex, Cursor, OpenCode)
- [x] Clear use case (portable Go workflows)
- [x] Includes described (44 SKILL.md skills, references, examples)
- [x] Status: Active
- [x] Risk: Medium

**Description:** Curated, portable set of 44 Go agent skills (concurrency, context, testing, benchmarks, gRPC, error handling, security, idiomatic style). Normalized derivative of samber/cc-skills-golang + Cursor's thermonuclear review skill. MIT, agentskills.io spec (works on Claude Code/Codex/Cursor/OpenCode/Gemini CLI).