### PR TITLE
Add planning-with-files to Personal Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | Skill | Platform | Use case | Includes | Status | Risk |
 |---|---|---|---|---|---|
 | [Benkapner/claude-code-basecamp](https://github.com/Benkapner/claude-code-basecamp) | Claude Code | Workspace setup with skills, commands, and hooks. | Skills, commands, hooks | Active | Medium |
+| [OthmanAdi/planning-with-files](https://github.com/OthmanAdi/planning-with-files) | Claude Code, Codex, Cursor, Copilot, Gemini CLI, OpenCode | Keep long-running agent work resumable with persistent plans, findings, progress logs, and completion checks. | Skill, hooks, scripts, templates, tests | Active | Medium |
 | [Daaaaave/agentic-workspace-core](https://github.com/Daaaaave/agentic-workspace-core) | Claude Code, Codex | Repository-native memory, skills, and knowledge workflows. | Memory, AGENTS.md, skills, llms.txt | Active | Medium |
 | [WoJiSama/skill-based-architecture](https://github.com/WoJiSama/skill-based-architecture) | Cursor, Claude Code, Codex, Gemini | Meta-skill that distills repo knowledge into reusable skills. | Meta-skill, project skill generation | Active | Medium |
 | [mksglu/context-mode](https://github.com/mksglu/context-mode) | Claude Code, Codex, Cursor, MCP | Optimize agent context windows with tool-output sandboxing, session memory, MCP, and hooks. | MCP server, hooks, skills, memory, plugins | Active | Medium |


### PR DESCRIPTION
## Summary

- Add `OthmanAdi/planning-with-files` under Personal Productivity.
- Record its supported agent platforms and included skill, hooks, scripts, templates, and tests.
- Classify it as Active and Medium risk because it writes planning artifacts and can register lifecycle hooks.

## Evaluation

Score: 10/10

- Task clarity: 2/2. The repository defines a concrete workflow for keeping long-running agent tasks resumable through persistent plans, findings, and progress logs.
- Reusable structure: 2/2. It includes skill files, hooks, scripts, templates, references, examples, translations, and platform adapters.
- Platform and tool fit: 2/2. It documents support for Claude Code, Codex, Cursor, Copilot, Gemini CLI, OpenCode, and additional Agent Skills clients.
- Validation and examples: 2/2. It provides tests, CI checks, examples, evaluation documentation, and installation verification.
- Maintenance and safety: 2/2. It is actively maintained under the MIT license and documents prompt-injection boundaries, plan attestation, opt-in gating, and bounded stop behavior.

## Verification

- Confirmed the canonical repository was not already listed
- Confirmed every skill table row has six fields
- Confirmed the new entry appears once under Personal Productivity
- Confirmed the canonical repository link returns HTTP 200
- Confirmed the three latest source-repository test workflows passed
- Ran `git diff --check`
