### PR TITLE
Add AgentBody skill to Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [hashgraph-online/hol-guard](https://github.com/hashgraph-online/hol-guard) | Codex, Claude Code, Cursor, MCP | Scan plugins, skills, and MCP servers before tools run. | Security scanner, CLI, policy checks | Active | High |
 
 ## Research
+| [agentbody/skills](https://github.com/agentbody/skills) | Claude Code, Codex, Generic Agent | Unified API router for public LinkedIn, YouTube, TikTok, Reddit, Instagram, X, and Xiaohongshu data plus document parsing and text humanization. | Skill, API routing workflow, safety rules | Active | Medium |
 
 | Skill | Platform | Use case | Includes | Status | Risk |
 |---|---|---|---|---|---|


### PR DESCRIPTION
Adds a new row to the Research section table.

- Canonical source: https://github.com/agentbody/skills
- Unified API router for public LinkedIn, YouTube, TikTok, Reddit, Instagram, X, and Xiaohongshu data plus document parsing and text humanization
- MIT licensed, includes SKILL.md with safety rules and credential handling
- Affiliation: I maintain this skill