### PR TITLE
Add d1v deployment skill to DevOps and Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Inclusion guide: 8-10 = recommended, 6-7 = acceptable with caveats, 4-5 = use wi
 | [AmoyLab/Unla](https://github.com/AmoyLab/Unla) | MCP | Transform APIs and MCP servers into managed MCP capabilities. | Gateway, UI, Docker deployment | Active | Medium |
 | [milisp/mcp-linker](https://github.com/milisp/mcp-linker) | MCP, Claude, Cursor | Sync MCP server configurations across clients. | MCP manager, config sync | Active | Medium |
 | [hashgraph-online/hol-guard](https://github.com/hashgraph-online/hol-guard) | Codex, Claude Code, Cursor, MCP | Scan plugins, skills, and MCP servers before tools run. | Security scanner, CLI, policy checks | Active | High |
+| [d1vai/d1v-cli](https://github.com/d1vai/d1v-cli/tree/main/skills/d1v) | Codex, Claude Code | Deploy AI-built web projects with verified previews and explicitly confirmed production releases. | CLI, deployment workflow skill, references | Active | High |
 
 ## Research
 


### PR DESCRIPTION
## Summary

Adds the official [d1v deployment Skill](https://github.com/d1vai/d1v-cli/tree/main/skills/d1v) to **DevOps and Cloud**.

## Evaluation score: 10/10

| Area | Score | Evidence |
|---|---:|---|
| Task clarity | 2/2 | Covers project deployment, verified preview completion, and production-release confirmation. |
| Reusable structure | 2/2 | Canonical `SKILL.md` plus CLI-backed workflow and references. |
| Platform and tool fit | 2/2 | Officially documented for Codex and Claude Code. |
| Validation and examples | 2/2 | The workflow waits for verified Preview completion before reporting success. |
| Maintenance and safety | 2/2 | Public MIT source, recent maintenance, and explicit interactive confirmation before Production releases. |

## Checklist

- [x] Link points to the canonical repository and Skill path.
- [x] The project is a reusable workflow, not a prompt dump.
- [x] Evaluation score is at least 6.
- [x] Platform, use case, includes, status, and risk are filled.
- [x] Safety caveat is reflected by the `High` risk classification: the workflow can create Production releases, so it requires an interactive TTY and explicit user confirmation.
- [x] Public-link check and `git diff --check` passed.

## Disclosure

I am affiliated with d1v, the maintainer of the linked Skill. This PR changes one documentation-table row only; no target-project commands were run.
