### PR TITLE
Add SecHelix (security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ These projects can be valuable, but they involve sensitive domains such as secur
 | Skill | Platform | Use case | Includes | Status | Risk |
 |---|---|---|---|---|---|
 | [gadievron/raptor](https://github.com/gadievron/raptor) | Claude Code | Offensive and defensive security agent workflows. | Rules, sub-agents, skills, security tools | Use with care | High |
+| [omarmohelal/SecHelix](https://github.com/omarmohelal/SecHelix) | Claude Code, Generic Agent | Evidence-first application-security review with independent verification of every candidate finding. | Skill, 546-check catalog, JSON schemas, gold packs, scanner adapters, eval fixtures | Active | High |
 | [matank001/cursor-security-rules](https://github.com/matank001/cursor-security-rules) | Cursor | Security rules for AI-assisted development workflows. | Cursor rules, guardrails | Use with care | High |
 | [LLMQuant/awesome-trading-agents](https://github.com/LLMQuant/awesome-trading-agents) | Generic Agent, MCP | Trading agents, market research, and execution resources. | Awesome list, MCP servers, agent skills | Use with care | High |
 | [soxoj/awesome-osint-mcp-servers](https://github.com/soxoj/awesome-osint-mcp-servers) | MCP | OSINT MCP servers and investigative tooling. | Awesome list, MCP resources | Use with care | High |


### PR DESCRIPTION
One row added to the security table.

```md
| [omarmohelal/SecHelix](https://github.com/omarmohelal/SecHelix) | Claude Code, Generic Agent | Evidence-first application-security review with independent verification of every candidate finding. | Skill, 546-check catalog, JSON schemas, gold packs, scanner adapters, eval fixtures | Active | High |
```

**Risk is High deliberately** — your risk guide lists security testing under High, and that is what this does. **Platform lists only Claude Code and Generic Agent**: the repo also ships `.github/skills/` for Copilot and `.agents/skills/` for Codex, and both are documented discovery paths, but no Copilot or Codex session was observed loading the skill here. The project's own compatibility matrix records those as `DOCUMENTED`, not `VERIFIED`, so I left them out of the column rather than overstate.

### Self-assessment against your rubric

Scored conservatively; please re-score.

| Area | Score | Evidence |
|---|---:|---|
| Task clarity | 2 | Reviews a codebase you are authorized to test. Input is a repository plus a scope and authorization record; output is a schema-validated report with findings, evidence chains, and a release decision. Target user is a developer or AppSec engineer. |
| Reusable structure | 2 | Not a prompt. `SKILL.md` plus a 546-item check catalog (21 families × 26 verification lenses), 17 specialist role profiles, 15 JSON Schema Draft 2020-12 contracts, 18 Gold Check Packs, 11 read-only scanner adapters, a report renderer, and a release gate. Python standard library only. |
| Platform and tool fit | 2 | Portable Agent Skills format; Claude Code plugin verified by cold install; documented paths for Codex and Copilot. |
| Validation and examples | **1** | 242 tests, CI validation, JSON schemas, worked examples, and one published case study — **but the public benchmark is `NOT_MEASURED`**, so I am not claiming this dimension. See below. |
| Maintenance and safety | 2 | Active, Apache-2.0, `SECURITY.md` with disclosure policy, requires explicit authorization, dynamic testing is bounded and non-destructive by default, release gate fails closed. |

**Total: 9.** If you read "Validation" as requiring measured performance, score it 0 and the total is 8 — still in your recommended band, and I would rather you arrive there honestly.

### The honest part

- **Public benchmark is `NOT_MEASURED`.** The blocker is recorded machine-readably as `CONTAMINATED_EVALUATOR`: the eval fixtures were authored by assistant sessions working in the repository, so scoring one of them measures recall of authored answers rather than review capability. A blind packet exists so an uncontaminated evaluator can run without repository access.
- The repo contains a keyword baseline flagged `is_sechelix_result: false` — a regex matcher used to validate the scoring harness and evidence fixture difficulty. It is not a SecHelix score.
- One published case study: an authorized owner self-audit in which one MEDIUM finding was verified, fixed and regression-proved, and one plausible high-severity XSS candidate was independently **refuted**. It demonstrates both detection and false-positive rejection; it measures nothing general.
- Alpha software. Contracts can still change.

No accuracy, precision, recall, or detection-rate claim is made anywhere in this submission, and no comparison to any other entry on the list.

I am the author.